### PR TITLE
fixed arch builds and k3s not starting on openrc

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,9 +20,6 @@ jobs:
           - v1.23.9+k3s1
           - v1.22.11+k3s2
           - v1.21.14+k3s1
-        platform:
-          - linux/amd64
-          - linux/arm64
     env:
       REGISTRY: quay.io
       REGISTRY_USER: ${{ secrets.QUAY_USERNAME }}
@@ -36,6 +33,6 @@ jobs:
       - run: echo $REGISTRY_PASSWORD | docker login -u $REGISTRY_USER --password-stdin $REGISTRY
       - run: env | grep ACTIONS_ID_TOKEN_REQUEST > .env
       - run: env | grep REGISTRY >> .env
-      - run: earthly --ci --push --platform=${{ matrix.platform }} +docker --K3S_VERSION=${{ matrix.k3s-version }} --BASE_IMAGE=${{ matrix.base-image }}
-      - run: earthly --ci +cosign --K3S_VERSION=${{ matrix.k3s-version }} --BASE_IMAGE=${{ matrix.base-image }}
+      - run: earthly --ci --push +docker-all-platforms --K3S_VERSION=${{ matrix.k3s-version }} --BASE_IMAGE=${{ matrix.base-image }}
+      - run: earthly --ci +cosign-all-platforms --K3S_VERSION=${{ matrix.k3s-version }} --BASE_IMAGE=${{ matrix.base-image }}
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -33,13 +33,10 @@ jobs:
           - v1.23.9+k3s1
           - v1.22.11+k3s2
           - v1.21.14+k3s1
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
       - uses: actions/checkout@v2
       - uses: docker-practice/actions-setup-docker@master
       - uses: earthly/actions-setup@v1
         with:
           version: "latest"
-      - run: earthly --ci --platform=${{ matrix.platform }} +docker --K3S_VERSION=${{ matrix.k3s-version }} --BASE_IMAGE=${{ matrix.base-image }}
+      - run: earthly --ci +docker-all-platforms --K3S_VERSION=${{ matrix.k3s-version }} --BASE_IMAGE=${{ matrix.base-image }}

--- a/Earthfile
+++ b/Earthfile
@@ -49,16 +49,16 @@ VERSION:
 
     SAVE ARTIFACT VERSION VERSION
 
-build-provider:
-    FROM +go-deps
-    DO +BUILD_GOLANG --BIN=agent-provider-k3s --SRC=main.go
-
 lint:
     FROM golang:$GOLANG_VERSION
     RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $GOLINT_VERSION
     WORKDIR /build
     COPY . .
     RUN golangci-lint run
+
+build-provider:
+    FROM +go-deps
+    DO +BUILD_GOLANG --BIN=agent-provider-k3s --SRC=main.go
 
 docker:
     DO +VERSION
@@ -118,3 +118,11 @@ cosign:
     RUN cosign sign $IMAGE_REPOSITORY/${BASE_IMAGE_NAME}-k3s:${BASE_IMAGE_TAG}
     RUN cosign sign $IMAGE_REPOSITORY/${BASE_IMAGE_NAME}-k3s:${BASE_IMAGE_TAG}_${K3S_VERSION_TAG}
     RUN cosign sign $IMAGE_REPOSITORY/${BASE_IMAGE_NAME}-k3s:${BASE_IMAGE_TAG}_${K3S_VERSION_TAG}_${VERSION}
+
+docker-all-platforms:
+     BUILD --platform=linux/amd64 +docker
+     BUILD --platform=linux/arm64 +docker
+
+cosign-all-platforms:
+     BUILD --platform=linux/amd64 +cosign
+     BUILD --platform=linux/arm64 +cosign

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func clusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 					If:   "[ -x /sbin/openrc-run ]",
 					Commands: []string{
 						fmt.Sprintf("rc-update add %s default >/dev/null", systemName),
+						fmt.Sprintf("service %s start", systemName),
 					},
 				},
 				{


### PR DESCRIPTION
This pr addressed two issues.  When images were being published they were being published for different arches under the same tag.  This pr updates ci to build them at the same time and push one manifest.

K3s was also not being started on openrc systems.